### PR TITLE
Fix compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: trusty
+sudo: false
+
+language: cpp
+
+os: linux
+
+addons:
+  apt:
+    packages:
+    - gfortran
+    - libarmadillo-dev
+
+compiler:
+  - clang
+  - gcc
+
+script:
+  - mkdir build
+  - cd build
+  - cmake -DWITH_COVERAGE=On ..
+  - make -j 2
+  - make test
+  - curl -s https://codecov.io/bash | bash -

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Compiler config
 enable_language (Fortran)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -march=native")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Wpedantic -Werror -march=native")
 
 # Coverage report
 option(WITH_COVERAGE "Generate code coverage report" OFF)
@@ -25,7 +25,7 @@ if(WITH_COVERAGE)
 endif()
 
 # Included files
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include INC_LIST)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Source files
 aux_source_directory(./src SRC_LIST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Name of project
 project(wignerSymbols)
+enable_testing()
+
 set (wignerSymbols_VERSION_MAJOR 0)
 set (wignerSymbols_VERSION_MINOR 2)
 set (wignerSymbols_VERSION_RELEASE 0)
@@ -13,6 +15,14 @@ endif()
 # Compiler config
 enable_language (Fortran)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -march=native")
+
+# Coverage report
+option(WITH_COVERAGE "Generate code coverage report" OFF)
+if(WITH_COVERAGE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the build type" FORCE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+  link_libraries(gcov)
+endif()
 
 # Included files
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include INC_LIST)
@@ -39,6 +49,8 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}
     PROPERTIES
         VERSION ${wignerSymbols_VERSION_MAJOR}.${wignerSymbols_VERSION_MINOR}.${wignerSymbols_VERSION_RELEASE}
         SOVERSION ${wignerSymbols_VERSION_MAJOR}.${wignerSymbols_VERSION_MINOR}.${wignerSymbols_VERSION_RELEASE})
+
+add_subdirectory(tests)
 
 # Install directories
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)

--- a/src/wignerSymbols-cpp.cpp
+++ b/src/wignerSymbols-cpp.cpp
@@ -454,7 +454,7 @@ double wigner6j(double l1, double l2, double l3,
 }
 
 double wigner3j_auxA(double l1, double l2, double l3,
-						double m1, double m2, double m3)
+                                               double m1, double /*m2*/, double /*m3*/)
 {
 	double T1 = l1*l1-pow(l2-l3,2.0);
 	double T2 = pow(l2+l3+1.0,2.0)-l1*l1;
@@ -475,7 +475,7 @@ double wigner3j_auxB(double l1, double l2, double l3,
 }
 
 double wigner6j_auxA(double l1, double l2, double l3,
-						double l4, double l5, double l6)
+						double /*l4*/, double l5, double l6)
 {
 	double T1 = l1*l1-pow(l2-l3,2.0);
 	double T2 = pow(l2+l3+1.0,2.0)-l1*l1;

--- a/src/wignerSymbols-fortran.cpp
+++ b/src/wignerSymbols-fortran.cpp
@@ -18,17 +18,13 @@ std::vector<double> wigner3j_f(double l2, double l3, double m1, double m2, doubl
 
   // We prepare the output values.
   double l1min, l1max;
-  double thrcof [size];
+  std::vector<double> thrcof(size);
   int ierr;
 
   // External function call.
-  drc3jj_wrap(l2,l3,m2,m3,&l1min,&l1max,thrcof,size,&ierr);
+  drc3jj_wrap(l2,l3,m2,m3,&l1min,&l1max,thrcof.data(),size,&ierr);
 
-  // We copy the values of the array into a vector.
-  std::vector<double> thrcof_v(size);
-  thrcof_v.assign(thrcof, thrcof + size);
-
-  return thrcof_v;
+  return thrcof;
 }
 
 /*! Computes the Wigner-3j symbol for given l1,l2,l3,m1,m2,m3. We
@@ -55,11 +51,11 @@ double wigner3j_f(double l1, double l2, double l3,
 
   // We prepare the output values.
   double l1min, l1max;
-  double thrcof [size];
+  std::vector<double> thrcof(size);
   int ierr;
 
   // External function call.
-  drc3jj_wrap(l2,l3,m2,m3,&l1min,&l1max,thrcof,size,&ierr);
+  drc3jj_wrap(l2,l3,m2,m3,&l1min,&l1max,thrcof.data(),size,&ierr);
 
   // We fetch and return the value with the proper l1 value.
   int index = (int)(l1-l1min);
@@ -95,11 +91,11 @@ double wigner6j_f(double l1, double l2, double l3,
 
   // We prepare the output values
   double l1min, l1max;
-  double sixcof [size];
+  std::vector<double> sixcof(size);
   int ierr;
 
   // External function call
-  drc6j_wrap(l2,l3,l4,l5,l6,&l1min,&l1max,sixcof,size,&ierr);
+  drc6j_wrap(l2,l3,l4,l5,l6,&l1min,&l1max,sixcof.data(),size,&ierr);
 
   // We fetch and return the coefficient with the proper l1 value.
   int index = (int)(l1-l1min);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(gh-issue-1 gh-issue-1.cpp)
+target_link_libraries(gh-issue-1 ${PROJECT_NAME})
+add_test(NAME gh-issue-1 COMMAND gh-issue-1)
+
+add_executable(gh-issue-2 gh-issue-2.cpp)
+target_link_libraries(gh-issue-2 ${PROJECT_NAME})
+add_test(NAME gh-issue-2 COMMAND gh-issue-2)
+
+find_package(Armadillo)
+include_directories(${ARMADILLO_INCLUDE_DIRS})
+add_executable(testWigner testWigner.cpp)
+target_link_libraries(testWigner ${PROJECT_NAME} ${ARMADILLO_LIBRARIES})
+add_test(NAME testWigner COMMAND testWigner 10)

--- a/tests/gh-issue-1.cpp
+++ b/tests/gh-issue-1.cpp
@@ -18,7 +18,7 @@
 
 #include <wignerSymbols.h>
 
-int main (int argc, char* argv[])
+int main ()
 {
   double test11 = WignerSymbols::wigner3j(325, 999, 1221, 280, 899, -1179);
   double test12 = WignerSymbols::wigner3j(999, 1221, 325,  899, -1179, 280);
@@ -69,6 +69,9 @@ int main (int argc, char* argv[])
   std::vector<double> test5 = WignerSymbols::wigner3j(856, 1200, 464, -828, 364);
   double test51 = WignerSymbols::wigner3j(751, 856, 1200, 464, -828, 364);
   double test52 = WignerSymbols::wigner3j_f(751, 856, 1200, 464, -828, 364);
+  std::cout << "C++ impl.: " << test51 << std::endl;
+  std::cout << "FOR impl.: " << test52 << std::endl;
+  std::cout << std::endl;
 
 /*
 [ 841  379 1011 -631  313  318] -2.44096504011e-41 -0.0

--- a/tests/gh-issue-1.cpp
+++ b/tests/gh-issue-1.cpp
@@ -66,9 +66,9 @@ int main (int argc, char* argv[])
   std::cout << "FOR impl.: " << test42 << std::endl;
   std::cout << std::endl;
 
-std::vector<double> test5 = WignerSymbols::wigner3j(856, 1200, 464, -828, 364);
-double test51 WignerSymbols::wigner3j(751, 856, 1200, 464, -828, 364);
-double test52 WignerSymbols::wigner3j_f(751, 856, 1200, 464, -828, 364);
+  std::vector<double> test5 = WignerSymbols::wigner3j(856, 1200, 464, -828, 364);
+  double test51 = WignerSymbols::wigner3j(751, 856, 1200, 464, -828, 364);
+  double test52 = WignerSymbols::wigner3j_f(751, 856, 1200, 464, -828, 364);
 
 /*
 [ 841  379 1011 -631  313  318] -2.44096504011e-41 -0.0

--- a/tests/gh-issue-2.cpp
+++ b/tests/gh-issue-2.cpp
@@ -18,7 +18,7 @@
 
 #include <wignerSymbols.h>
 
-int main (int argc, char* argv[])
+int main ()
 {
   double test11 = WignerSymbols::wigner3j(325, 999, 1221, 280, 899, -1179);
   double test12 = WignerSymbols::wigner3j(999, 1221, 325,  899, -1179, 280);

--- a/tests/testWigner.cpp
+++ b/tests/testWigner.cpp
@@ -52,6 +52,10 @@ int main(int argc, char* argv[])
 	timesF.save("timesF.dat",raw_ascii);
 
 	// Generate values for l1, l2 and derive the rest of the allowed values.
+        if (argc != 2) {
+            std::cerr << "Usage: " << argv[0] << " <lMax>\n";
+            return 1;
+        }
 	double lMax = atof(argv[1]);
 	colvec lVec = linspace(0,lMax,lMax+1);
 
@@ -204,7 +208,7 @@ double seconSumOverL3(double l1, double l2, double l6)
 
 	double value = (l6==0.0 ? sqrt((2.*l1+1.)*(2.*l2+1.)) : 0.0) ;
 
-	double diff = std::fabs(value-sum);
+	//double diff = std::fabs(value-sum);
 
 	return std::fabs(value-sum);
 	
@@ -229,7 +233,7 @@ double timingWignerSymbolsF(double l2, double l3, double m1, double m2, double m
 	clock_t start = clock();
 
 	// We call the subroutine.
-	double test = WignerSymbols::wigner3j(l2+l3,l2,l3,m1,m2,m3);
+	WignerSymbols::wigner3j(l2+l3,l2,l3,m1,m2,m3);
 
 	clock_t end = clock();
 


### PR DESCRIPTION
The code caused several compiler warnings, which I fixed.
I also added more warning levels to the CMake file.
On top of that I specified `-Werror` to prevent the introduction of new warnings.

The code can be automatically built and tested on Travis CI.
Code coverage is automatically determined and uploaded to CodeCov.

Optionally you can add these badges to your README.
[![Build status](https://travis-ci.org/hmenke/wignerSymbols.svg?branch=travis)](https://travis-ci.org/hmenke/wignerSymbols) [![Code coverage report](https://codecov.io/gh/hmenke/wignerSymbols/branch/travis/graph/badge.svg)](https://codecov.io/gh/hmenke/wignerSymbols/branch/travis)
Those badges of course point to my repo, below is the markdown you'd have to insert for your own.
```
[![Build status](https://travis-ci.org/valandil/wignerSymbols.svg?branch=master)](https://travis-ci.org/valandil/wignerSymbols)
[![Code coverage report](https://codecov.io/gh/valandil/wignerSymbols/branch/master/graph/badge.svg)](https://codecov.io/gh/valandil/wignerSymbols)
```

  